### PR TITLE
Add support for downloading releases.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:1.19.9
-ENV RESOLVER=127.0.0.1 PORT=8080
+ENV PORT=8080
 # Default orgs, must be pipe separated as are fed into a regex match
 # Can be overridden via run time env var
 ENV ORGS=opensafely|opensafely-core|opensafely-actions|graphnet-opensafely

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 IMAGE_NAME ?= proxy
+export RESOLVER ?= 127.0.0.53
+export PORT ?= 8080
 
 .PHONY: build
 build: Dockerfile
@@ -7,8 +9,9 @@ build: Dockerfile
 .PHONY: run
 run:
 	docker kill $(IMAGE_NAME) && sleep 1 || true
-	docker run -d --rm -p 80:8080 --name $(IMAGE_NAME) $(IMAGE_NAME)
+	docker run -d --rm -e RESOLVER -e PORT --network=host --name $(IMAGE_NAME) $(IMAGE_NAME)
 	sleep 1
+
 
 .PHONY: test
 test: run

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository produces a Docker image that uses nginx to host two proxy
 domains:
  
  * github-proxy.opensafely.org: this provides access to *only* opensafely
-   repositories hosted on https://github.com, and not other repositories.
+   repositories hosted on https://github.com, and not other repositories. It
+   also restricts access to certain paths within those organisations.
 
  * docker-proxy.opensafely.org: this provides read only access to docker images
    published by specific Github organistions on https://ghcr.io, the Github
@@ -17,19 +18,21 @@ domains:
 
 
 ## Building
+ 
+To build
 
-To build:
+    make build
 
-    docker build . -t ghcr.io/opensafely-core/opensafely-proxy
+## Running
 
-By default, it uses 127.0.0.1 as a DNS resolver, and runs on port 8080. You can
-override those values with the environment variables RESOLVER and PORT
-respectively. 
+Because we use handle redirects dyanmically, we need to configure a DNS
+resolver at run time. The Makefile uses 127.0.0.53 by default, assumes you are
+running modern Ubuntu, you may need to use something different
 
-or
+    make run [RESOLVER=...]
 
-    docker run -d --rm ghcr.io/opensafely-core/opensafely-proxy
-
+This will run the container in docker on port 8080. It uses --network=host in
+order to have access to the hosts resolver at 127.0.0.53
 
 ## Testing 
 
@@ -37,10 +40,10 @@ To run basic tests:
 
     make test
 
-This will build and run the image and run ./ci-tests.sh, which is basic http tests.
+This will build and run the image and run ./ci-tests.sh, which is basic http
+tests.
 
 Full integraton tests can only be run against the current production
 deployment, as it requires TLS and DNS:
 
     ./full-tests.sh
-

--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -38,8 +38,8 @@ try() {
 
     code="$(
         curl --verbose --output "$body" \
-        --resolve github-proxy.opensafely.org:80:127.0.0.1 \
-        --resolve docker-proxy.opensafely.org:80:127.0.0.1 \
+        --connect-to github-proxy.opensafely.org:80:127.0.0.1:8080 \
+        --connect-to docker-proxy.opensafely.org:80:127.0.0.1:8080 \
         --write-out "%{http_code}"\
         "$url" \
         2> "$headers"
@@ -112,6 +112,10 @@ assert-header 'Content-Type: text/plain; charset=UTF-8'
 # test keys
 try github-proxy.opensafely.org/bloodearnest.keys 200
 assert-in-body ed25519
+
+# test download
+try github-proxy.opensafely.org/opensafely-core/backend-server/releases/download/v0.1/test-download 200
+assert-in-body test
 
 ### docker-proxy.opensafely.org ###
 

--- a/github.com.conf.template
+++ b/github.com.conf.template
@@ -25,23 +25,51 @@ server {
     proxy_request_buffering off;
     chunked_transfer_encoding on;
 
+    # We need a resolver configured so we can dynamically look up domains when
+    # redirecting. We make it an env var so that we can switch it out in prod
+    # for the Digital Ocean resolver
+    resolver ${RESOLVER};
 
     # only opensafely, opensafely-core, and opensafely-actions orgs can be accessed
     # location regex cannot match on query parameters
+
+    # basic git operations
     location ~ ^/(${ORGS})/[^/]+/info/refs {
         if ($args !~ "service=git-(upload|receive)-pack") { return 404; }
         proxy_pass https://github.com;
         proxy_redirect default;
     }
 
+    # basic git operations
     location ~ ^/(${ORGS})/[^/]+/git-(upload|receive)-pack {
         proxy_pass https://github.com;
         proxy_redirect default;
     }
 
+    # allow ssh keys to be retreived for a user
     location ~ ^/[^/]+\.keys {
+        limit_except GET { deny all; }
         proxy_pass https://github.com;
         proxy_redirect default;
+    }
+
+    # allow release artifcats to be download from specific repo only
+    location ~ ^/opensafely-core/backend-server/releases/download {
+        limit_except GET { deny all; }
+        proxy_pass https://github.com;
+        proxy_redirect default;
+        # releases download redirects to an S3 bucket, which is not accessible from
+        # backends. So handle redirects to S3 here in the proxy rather than
+        # passing back to the client
+        proxy_intercept_errors on;
+        error_page 301 302 307 = @handle_redirect;
+    }
+
+    location @handle_redirect {
+        # set saves the initial response's Location: header
+        set $redirect '$upstream_http_location';
+        # proxy the AWS location back to the client
+        proxy_pass $redirect;
     }
 
     location / {

--- a/github.com.conf.template
+++ b/github.com.conf.template
@@ -53,12 +53,12 @@ server {
         proxy_redirect default;
     }
 
-    # allow release artifcats to be download from specific repo only
+    # allow release artifacts to be downloaded from specified repo only
     location ~ ^/opensafely-core/backend-server/releases/download {
         limit_except GET { deny all; }
         proxy_pass https://github.com;
         proxy_redirect default;
-        # releases download redirects to an S3 bucket, which is not accessible from
+        # `releases/download` redirects to an S3 bucket, which is not accessible from
         # backends. So handle redirects to S3 here in the proxy rather than
         # passing back to the client
         proxy_intercept_errors on;


### PR DESCRIPTION
This involves handling 302 redirects in a simlar manner to how we handle
ghcr.io image download redirects.

The ci-tests actually test this functionality, but that means we *must*
set a RESOLVER env var for the tests to run. The Makefile provides
a reasonable default, but may need overriding.
