### PR TITLE
fix: install just into the build CI

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -15,6 +15,7 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@master
+    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
     - name: Build image
       run: just build
     - name: Run tests


### PR DESCRIPTION
* missed in https://github.com/opensafely-core/proxy/pull/34/files 
