### PR TITLE
Proxy Honeycomb markers

### DIFF
--- a/api.honeycomb.io.conf.template
+++ b/api.honeycomb.io.conf.template
@@ -1,0 +1,11 @@
+server {
+    server_name honeycomb-api-proxy.opensafely.org;
+    listen ${PORT};
+
+    # just allow markers
+    location /1/markers/ {
+        proxy_pass https://api.honeycomb.io;
+        proxy_ssl_server_name on;
+    }
+}
+

--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -41,6 +41,7 @@ try() {
         --connect-to github-proxy.opensafely.org:80:127.0.0.1:8080 \
         --connect-to docker-proxy.opensafely.org:80:127.0.0.1:8080 \
         --connect-to opencodelists-proxy.opensafely.org:80:127.0.0.1:8080 \
+        --connect-to honeycomb-api-proxy.opensafely.org:80:127.0.0.1:8080 \
         --write-out "%{http_code}"\
         "$url" \
         2> "$headers"
@@ -172,5 +173,8 @@ assert-header 'Content-Type: application/json; charset=UTF-8'
 
 try opencodelists-proxy.opensafely.org/api/v1/dmd-mapping/ 200
 try opencodelists-proxy.opensafely.org/api/v1/codelist/ 404
+
+try honeycomb-api-proxy.opensafely.org/1/markers/jobrunner 401
+assert-in-body 'unknown API key'
 
 exit $return_code

--- a/docs/ADR-0001.md
+++ b/docs/ADR-0001.md
@@ -1,0 +1,33 @@
+# 1. Proxy marker API direct to Honeycomb
+
+Date: 2023-09-19
+
+## Status
+
+Accepted
+
+## Context
+
+We currently emit detailed telemetry from jobrunner using otel. Otel is
+a standard, so use a standard otel-collector instance hosted at
+collector.opensafely.org.
+
+Honeycomb also supports [markers](https://docs.honeycomb.io/api/tag/Markers),
+used to mark events such as deployments.  We want emit to markers from our
+backends for events like deployments, image updates, or maintenance jobs.
+Markers are not part of the otel standard, so we cannot proxy them via the
+otel-collector.
+
+## Decision
+
+We will add a proxy stanza to the proxy for *just* the marker API. It will be easy to
+extend to other Honeycomb APIs if needed.
+
+
+## Consequences
+
+We will be able to emit markers from the backend.
+
+In theory, a compromised backend now has another channel to honeycomb to egress
+data. But it already has a richer way to do so via otel anyway, so this doesn't change the 
+risk doesn't change.


### PR DESCRIPTION
This is not ready yet.

We need to a) authenticate the client, like we do for otel-gateway b)
force using our writekey, so an attacker couldn't write data to
a different HC account.

Other proxies all include the org in the url, so its simpler to
restrict. Honeycomb users the auth token as both auth and identity, so
it is not as simple.
