### PR TITLE
Fix SNI/Host header mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ domains:
  * opencodelists-proxy.opensafely.org: this provides access to a single OpenCodelists
    API endpoint.
 
+ * changelogs.opensafely.org: this allows us to use the do-release-upgrade tool
+   to perform major OS upgrades.
 
 ## Building
  

--- a/ci-tests.sh
+++ b/ci-tests.sh
@@ -117,7 +117,6 @@ assert-header() {
     fi
 }
 
-
 ### github-proxy.opensafely.org ###
 
 # test we can query the clone metadata endpoint
@@ -138,7 +137,6 @@ try github-proxy.opensafely.org/opensafely/documentation/info/refs?service=git-r
 
 # test we cannot query the actual push endpoint
 git-post git-recieve-pack github-proxy.opensafely.org/opensafely/documentation/git-receive-pack 403
-
 
 # test we cannot access other parts of the repo
 try github-proxy.opensafely.org/opensafely/documentation 403
@@ -193,10 +191,15 @@ try "docker-proxy.opensafely.org/v2/opensafely-core/busybox/blobs/$digest?" 200 
 
 ### opencodelists-proxy.opensafely.org ###
 
+# we should allow this specific call...
 try opencodelists-proxy.opensafely.org/api/v1/dmd-mapping/ 200
+
+# ...but not any others
 try opencodelists-proxy.opensafely.org/api/v1/codelist/ 404
 
+### changelogs.opensafely.org ###
 
+# This allows us to use the do-release-upgrade tool to perform major backend OS upgrades.
 try changelogs.opensafely.org/meta-release-lts 200
 
 exit $return_code

--- a/ghcr.io.conf.template
+++ b/ghcr.io.conf.template
@@ -40,6 +40,8 @@ server {
         # explicitly change host header to expected host
         proxy_set_header Host ghcr.io;
         proxy_redirect default;
+        # ensure Host header and SNI domain match
+        proxy_ssl_server_name on;
         # hide upstream header
         proxy_hide_header www-authenticate;
         # add our modified header 
@@ -50,6 +52,8 @@ server {
     location /token {
         limit_except GET { deny all; }
         proxy_pass https://ghcr.io;
+        # ensure Host header and SNI domain match
+        proxy_ssl_server_name on;
         proxy_redirect default;
     }
 
@@ -57,6 +61,8 @@ server {
     location /v2/opensafely-core/ {
         limit_except GET { deny all; }
         proxy_pass https://ghcr.io;
+        # ensure Host header and SNI domain match
+        proxy_ssl_server_name on;
         proxy_redirect default;
         # ghcr.io redirects to an S3 bucket, which is not accessible from
         # backends. So handle redirects to S3 here in the proxy rather than
@@ -72,6 +78,8 @@ server {
         proxy_set_header Authorization "";
         # proxy the AWS location back to the client
         proxy_pass $redirect;
+        # ensure Host header and SNI domain match
+        proxy_ssl_server_name on;
     }
 
     location /v2/ {


### PR DESCRIPTION
Fastly started to care about it, and we didn't have it configured quite right, so this fixes it.

Also adds a full functional test for this, now that we understand the API flow for `docker pull` better.

- **Fix SNI/Host name mismatch**
- **Drive by add some missing comments in the tests and docs**
